### PR TITLE
Fix: Correct multiple PowerShell script errors

### DIFF
--- a/Config.psm1
+++ b/Config.psm1
@@ -5,8 +5,8 @@
 $ffUrl = "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip"
 $ffLocal = Join-Path $PSScriptRoot "ffmpeg.zip"
 $ffDir = Join-Path $PSScriptRoot "ffmpeg"
-$ffExe = Join-Path $ffDir "bin" "ffmpeg.exe"
-$ffProbeExe = Join-Path $ffDir "bin" "ffprobe.exe"
+$ffExe = Join-Path (Join-Path $ffDir "bin") "ffmpeg.exe"
+$ffProbeExe = Join-Path (Join-Path $ffDir "bin") "ffprobe.exe"
 
 $iamfToolsUrl = "https://github.com/AOMediaCodec/iamf/releases/latest/download/iamf-tools-windows-latest.zip" # Official URL for IAMF tools
 $iamfToolsZip = Join-Path $PSScriptRoot "iamf-tools.zip"

--- a/UI.psm1
+++ b/UI.psm1
@@ -54,7 +54,7 @@ function Show-MainApplicationWindow {
     function Add-Textbox($name, $y, $text, $width = 200) {
         $textbox = New-Object System.Windows.Forms.TextBox
         $textbox.Name = $name
-        $textbox.Location = New-Object System.Drawing.Point(250, $y - 3)
+        $textbox.Location = New-Object System.Drawing.Point(250, ([int]$y - 3))
         $textbox.Text = $text
         $textbox.Width = $width
         $form.Controls.Add($textbox)
@@ -64,7 +64,7 @@ function Show-MainApplicationWindow {
     function Add-ComboBox($name, $y, $items, $selectedItem, $width = 200) {
         $combobox = New-Object System.Windows.Forms.ComboBox
         $combobox.Name = $name
-        $combobox.Location = New-Object System.Drawing.Point(250, $y - 3)
+        $combobox.Location = New-Object System.Drawing.Point(250, ([int]$y - 3))
         $combobox.Items.AddRange($items)
         $combobox.SelectedItem = $selectedItem
         $combobox.Width = $width
@@ -122,7 +122,7 @@ function Show-MainApplicationWindow {
     Add-Label "Input Directory:" $yPos
     $inputDirTextBox = New-Object System.Windows.Forms.TextBox
     $inputDirTextBox.Name = "inputDirTextBox"
-    $inputDirTextBox.Location = New-Object System.Drawing.Point(150, $yPos -3) # Align with other textboxes
+    $inputDirTextBox.Location = New-Object System.Drawing.Point(150, ([int]$yPos - 3)) # Align with other textboxes
     $inputDirTextBox.Width = 320
     $inputDirTextBox.ReadOnly = $true
     $inputDirTextBox.Text = "Not selected"
@@ -132,7 +132,7 @@ function Show-MainApplicationWindow {
     Add-Label "Output Directory:" $yPos
     $outputDirTextBox = New-Object System.Windows.Forms.TextBox
     $outputDirTextBox.Name = "outputDirTextBox"
-    $outputDirTextBox.Location = New-Object System.Drawing.Point(150, $yPos -3) # Align with other textboxes
+    $outputDirTextBox.Location = New-Object System.Drawing.Point(150, ([int]$yPos - 3)) # Align with other textboxes
     $outputDirTextBox.Width = 320
     $outputDirTextBox.ReadOnly = $true
     $outputDirTextBox.Text = "Not selected"
@@ -173,7 +173,7 @@ function Show-MainApplicationWindow {
     $cancelProcessingButton.Name = "cancelProcessingButton"
     $cancelProcessingButton.Text = "Cancel Processing"
     $cancelProcessingButton.Width = 120
-    $cancelProcessingButton.Location = New-Object System.Drawing.Point($startButton.Right + 10, $yPos)
+    $cancelProcessingButton.Location = New-Object System.Drawing.Point(([int]$startButton.Right + 10), [int]$yPos)
     $cancelProcessingButton.Enabled = $false
     $form.Controls.Add($cancelProcessingButton)
 
@@ -181,7 +181,7 @@ function Show-MainApplicationWindow {
     $closeButton.Name = "closeButton"
     $closeButton.Text = "Close"
     $closeButton.Width = 90
-    $closeButton.Location = New-Object System.Drawing.Point($cancelProcessingButton.Right + 10, $yPos)
+    $closeButton.Location = New-Object System.Drawing.Point(([int]$cancelProcessingButton.Right + 10), [int]$yPos)
     $closeButton.DialogResult = "Cancel" # This will close the form if shown with ShowDialog()
     $form.CancelButton = $closeButton
     $form.Controls.Add($closeButton)

--- a/Utils.psm1
+++ b/Utils.psm1
@@ -150,7 +150,7 @@ function Run-Process {
         return @{
             ExitCode = -1 # Or a more specific error code for launch failure
             StdOut   = ""
-            StdErr   = "Failed to start process $FilePath: $($_.Exception.Message)"
+            StdErr   = "Failed to start process ${FilePath}: $($_.Exception.Message)"
         }
     }
 }


### PR DESCRIPTION
This commit addresses several errors reported during script execution:

1.  Corrected `Join-Path` usage in `Config.psm1` by nesting calls to handle multiple path segments, resolving "Impossible de trouver un paramètre positionnel" errors.
2.  Fixed "InvalidVariableReferenceWithDrive" in `Utils.psm1` by changing `$FilePath:` to `${FilePath}:` in a string, which also resolves the cascading `Import-Module` failures for `Utils.psm1`.
3.  Addressed `MethodNotFound : op_Subtraction` and `op_Addition` errors in `UI.psm1` by explicitly casting variables to `[int]` before their use in `System.Drawing.Point` calculations. This ensures that arithmetic operations are performed on compatible numeric types.