### PR TITLE
Fix: Correct PowerShell file encoding to UTF-8 with BOM

### DIFF
--- a/Config.psm1
+++ b/Config.psm1
@@ -1,4 +1,4 @@
-# Config.psm1 - Configuration settings for ov.ps1
+ï»¿# Config.psm1 - Configuration settings for ov.ps1
 # This file will hold parameters, paths, URLs, and default configuration values.
 
 # Chemins et URLs (moved from ov.ps1)

--- a/Main.ps1
+++ b/Main.ps1
@@ -1,4 +1,4 @@
-<#
+ï»¿<#
 .SYNOPSIS
     Script avancé pour le transcodage par lots en VVC (lossless) et audio IAMF,
     avec interface utilisateur, validation, et multithreading via ThreadJob.

--- a/Setup.psm1
+++ b/Setup.psm1
@@ -1,4 +1,4 @@
-# Setup.psm1 - Module and tool preparation for ov.ps1
+ï»¿# Setup.psm1 - Module and tool preparation for ov.ps1
 
 # Import utility functions (for Download-File, Extract-Archive)
 Import-Module .\Utils.psm1 -Force

--- a/Transcoding.psm1
+++ b/Transcoding.psm1
@@ -1,4 +1,4 @@
-# Transcoding.psm1 - Core file processing logic for ov.ps1
+ï»¿# Transcoding.psm1 - Core file processing logic for ov.ps1
 
 # Import utility functions (for Run-Process)
 Import-Module .\Utils.psm1 -Force

--- a/UI.psm1
+++ b/UI.psm1
@@ -1,4 +1,4 @@
-# UI.psm1 - Windows Forms UI for ov.ps1
+ï»¿# UI.psm1 - Windows Forms UI for ov.ps1
 
 # Import utilities (for Validate-Integer, Validate-Bitrate)
 Import-Module .\Utils.psm1 -Force

--- a/Utils.psm1
+++ b/Utils.psm1
@@ -1,4 +1,4 @@
-# Utils.psm1 - Utility functions for ov.ps1
+ï»¿# Utils.psm1 - Utility functions for ov.ps1
 
 #region Fonctions Utilitaires
 function Test-CommandExists {


### PR DESCRIPTION
This change updates all PowerShell scripts (.ps1, .psm1, .psd1) to use UTF-8 encoding with a Byte Order Mark (BOM). This ensures proper script interpretation and avoids potential issues with special characters across different environments.