### PR TITLE
Fix message in Transcoding.psm1

### DIFF
--- a/Transcoding.psm1
+++ b/Transcoding.psm1
@@ -37,7 +37,7 @@ function Invoke-FileProcessing {
             $outputFile = Join-Path $outDir $outputFileName
         }
 
-        Write-Host "Processus file: $inputFile" -ForegroundColor White
+        Write-Host "Traitement du fichier : $inputFile" -ForegroundColor White
         Write-Host "→ Sortie   : $outputFile" -ForegroundColor White
 
         # Fichiers temporaires


### PR DESCRIPTION
## Summary
- fix the French log text `Processus file` to read `Traitement du fichier`

## Testing
- `pwsh` could not be found so no tests were run

------
https://chatgpt.com/codex/tasks/task_b_68404247faf8832692a197b567aef2ba