### PR TITLE
Add persistence of GUI settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The script is designed to automate the download and setup of necessary external 
 
 ## 2. Features
 
-*   **User-Friendly GUI**: Configure all transcoding options through a Windows Forms interface.
+*   **User-Friendly GUI**: Configure all transcoding options through a Windows Forms interface. Settings are automatically saved in your user profile for the next launch.
 *   **Batch Processing**: Process multiple files from an input directory, maintaining subdirectory structures in the output.
 *   **VVC (H.266) Video Encoding**: Transcode video streams to VVC using FFmpeg with `libvvenc`.
     *   Configurable QP (Quantization Parameter) for quality control (0 for lossless).

--- a/UI.psm1
+++ b/UI.psm1
@@ -268,6 +268,9 @@ function Show-MainApplicationWindow {
         $Global:config.TargetVideoHeight = [int]$tbTargetVideoHeight.Text
         $Global:config.MaxParallelJobs = [int]$tbMaxParallelJobs.Text
         $Global:config.ShowFFmpegOutput = $cbShowFFmpegOutput.Checked
+        $Global:config.InitialInputDir = $inDir
+        $Global:config.InitialOutputDir = $outDir
+        Save-UserConfig
 
         # Disable settings controls and Start button, enable Cancel button
         & $enableSettingsControls $false
@@ -491,6 +494,23 @@ function Show-MainApplicationWindow {
             }
         }
         $form.Close()
+    })
+
+    # Persist settings when the window is closed
+    $form.add_FormClosing({
+        $Global:config.UseAMD = $cbUseAMD.Checked
+        $Global:config.GrabIAMFTools = $cbGrabIAMFTools.Checked
+        $Global:config.UseExternalIAMF = $cbUseExternalIAMF.Checked
+        $Global:config.InputExtensions = ($tbInputExtensions.Text -split ',') | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+        $Global:config.OutputContainer = $comboOutputContainer.SelectedItem
+        $Global:config.VvcQP = [int]$tbVvcQP.Text
+        $Global:config.IamfBitrate = $tbIamfBitrate.Text
+        $Global:config.TargetVideoHeight = [int]$tbTargetVideoHeight.Text
+        $Global:config.MaxParallelJobs = [int]$tbMaxParallelJobs.Text
+        $Global:config.ShowFFmpegOutput = $cbShowFFmpegOutput.Checked
+        if ($inputDirTextBox.Text -ne 'Not selected') { $Global:config.InitialInputDir = $inputDirTextBox.Text }
+        if ($outputDirTextBox.Text -ne 'Not selected') { $Global:config.InitialOutputDir = $outputDirTextBox.Text }
+        Save-UserConfig
     })
 
     $form.Show()


### PR DESCRIPTION
## Summary
- store config in `%APPDATA%\OtterVideo\config.json`
- load the user config on module import
- save user selections when starting transcoding and when closing the window
- note in README that the GUI remembers settings

## Testing
- `pwsh -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6840431c355c8326a0539575c87a1275