### PR TITLE
Fix curl alias detection and show IAMF options

### DIFF
--- a/UI.psm1
+++ b/UI.psm1
@@ -86,12 +86,12 @@ function Show-MainApplicationWindow {
     $yPos += 30
 
     $cbGrabIAMFTools = Add-Checkbox "GrabIAMFTools" "Télécharger iamf-tools" $yPos $Global:config.GrabIAMFTools
-    $cbGrabIAMFTools.Visible = $false
+    $cbGrabIAMFTools.Visible = $true
     $yPos += 30
 
     $cbUseExternalIAMF = Add-Checkbox "UseExternalIAMF" "Utiliser iamf-encoder.exe (nécessite iamf-tools)" $yPos $Global:config.UseExternalIAMF
     $cbUseExternalIAMF.Enabled = $Global:config.GrabIAMFTools
-    $cbUseExternalIAMF.Visible = $false
+    $cbUseExternalIAMF.Visible = $true
     $cbGrabIAMFTools.add_CheckedChanged({
         $cbUseExternalIAMF.Enabled = $cbGrabIAMFTools.Checked
         if (-not $cbGrabIAMFTools.Checked) { $cbUseExternalIAMF.Checked = $false }

--- a/Utils.psm1
+++ b/Utils.psm1
@@ -14,9 +14,10 @@ function Get-RemoteFile {
     )
     Write-Host "Téléchargement de $Description..." -ForegroundColor Cyan
     try {
-        if (Test-Command "curl") {
+        $curlCmd = Get-Command curl -ErrorAction SilentlyContinue
+        if ($curlCmd -and $curlCmd.CommandType -eq 'Application') {
             $curlArgs = @("-L", "-o", $OutFile, $Url)
-            $result = Start-ExternalProcess -FilePath "curl" -ArgumentList $curlArgs
+            $result = Start-ExternalProcess -FilePath $curlCmd.Source -ArgumentList $curlArgs
             if ($result.ExitCode -ne 0) {
                 throw "curl exit code $($result.ExitCode): $($result.StdErr)"
             }


### PR DESCRIPTION
## Summary
- ensure Get-RemoteFile only uses curl when it is an actual executable
- display IAMF related checkboxes in the GUI

## Testing
- `pwsh` commands could not be run: `bash: pwsh: command not found`

------
https://chatgpt.com/codex/tasks/task_b_68404e30d1808326a1c3fbde28419567